### PR TITLE
fix: update GitHub release action and use default GITHUB_TOKEN

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -43,13 +43,13 @@ jobs:
         run: cargo publish
 
       - name: Create GitHub Release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+        uses: softprops/action-gh-release@v1
         with:
           tag_name: ${{ github.ref_name }}
-          release_name: Release ${{ github.ref_name }}
+          name: Release ${{ github.ref_name }}
           body: |
             See the [full changelog](https://github.com/grasp-labs/ds-event-stream-rs-sdk/compare/${{ github.event.before }}...${{ github.sha }}) for details.
           draft: false
           prerelease: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- Replace deprecated actions/create-release@v1 with softprops/action-gh-release@v1
- Use default GITHUB_TOKEN instead of custom GH_TOKEN secret
- Fixes 'Bad credentials' error in release creation